### PR TITLE
Scheme relative URL instead of scheme guessing

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -103,16 +103,8 @@ class Pico {
 		$script_url  = (isset($_SERVER['PHP_SELF'])) ? $_SERVER['PHP_SELF'] : '';
 		if($request_url != $script_url) $url = trim(preg_replace('/'. str_replace('/', '\/', str_replace('index.php', '', $script_url)) .'/', '', $request_url, 1), '/');
 
-		$protocol = $this->get_protocol();
-		return rtrim(str_replace($url, '', $protocol . "://" . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']), '/');
+		return rtrim(str_replace($url, '', "//" . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']), '/');
 	}
-
-	function get_protocol()
-	{
-		preg_match("|^HTTP[S]?|is",$_SERVER['SERVER_PROTOCOL'],$m);
-		return strtolower($m[0]);
-	}
-
 }
 
 ?>


### PR DESCRIPTION
scheme guessing is tricky. I had a problem with my setup, because the PHP server didn't know the content was served other SSL.
the solution is easy: [scheme relative URL](http://stackoverflow.com/questions/3583103/network-path-reference-uri-scheme-relative-urls)
