### PR TITLE
Restricited access to draft pages

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -12,13 +12,29 @@ class Pico {
 		// Get our url path and trim the / of the left and the right
 		if($request_url != $script_url) $url = trim(preg_replace('/'. str_replace('/', '\/', str_replace('index.php', '', $script_url)) .'/', '', $request_url, 1), '/');
 
+		// Load the settings
+		$settings = $this->get_config();
+		$env = array('autoescape' => false);
+		if($settings['enable_cache']) $env['cache'] = CACHE_DIR;
+
+		if($settings['draft_auth'] !== false && strpos($url, '?draft') - strlen($url) + 6 === 0) $ext = '.draft';
+		else $ext = '.txt';
+
+		if($ext === '.draft') {
+			if(!$this->draft_auth($settings['draft_auth'])) {
+				header('WWW-Authenticate: Basic realm="'.$settings['site_title'].'"', true, 401);
+				exit;
+			}
+			$url = substr($url, 0, strlen($url) - 6);
+		}
+
 		// Get the file path
 		if($url) $file = strtolower(CONTENT_DIR . $url);
 		else $file = CONTENT_DIR .'index';
 
 		// Load the file
-		if(is_dir($file)) $file = CONTENT_DIR . $url .'/index.txt';
-		else $file .= '.txt';
+		if(is_dir($file)) $file = CONTENT_DIR . $url . '/index.' . $ext;
+		else $file .= $ext;
 
 		if(file_exists($file)) $content = file_get_contents($file);
 		else $content = file_get_contents(CONTENT_DIR .'404.txt');
@@ -26,11 +42,6 @@ class Pico {
 		$meta = $this->read_file_meta($content);
 		$content = preg_replace('#/\*.+?\*/#s', '', $content); // Remove comments and meta
 		$content = $this->parse_content($content);
-
-		// Load the settings
-		$settings = $this->get_config();
-		$env = array('autoescape' => false);
-		if($settings['enable_cache']) $env['cache'] = CACHE_DIR;
 		
 		// Load the theme
 		Twig_Autoloader::register();
@@ -46,6 +57,15 @@ class Pico {
 			'meta' => $meta,
 			'content' => $content
 		));
+	}
+
+	function draft_auth($credentials) {
+		if(!isset($_SERVER['HTTP_AUTHORIZATION']))
+		{
+			return false;
+		}
+
+		return $_SERVER['HTTP_AUTHORIZATION'] === 'Basic '.base64_encode($credentials);
 	}
 
 	function parse_content($content)
@@ -83,7 +103,8 @@ class Pico {
 			'site_title' => 'Pico',
 			'base_url' => $this->base_url(),
 			'theme' => 'default',
-			'enable_cache' => false
+			'enable_cache' => false,
+			'draft_auth' => false
 		);
 
 		foreach($defaults as $key=>$val){


### PR DESCRIPTION
To enable draft access, set the $config['draft_auth'] credentials. eg:
$config['draft_auth'] = 'username:password';
To create a draft, create a page with .draft instead of .txt extension,
you can then access the draft append ?draft to the url of the page (the browser will ask you for the username/password set int he config file). 
Once you're statified with the result, just change the extension to .txt

if draft_auth is not set in the config file, the draft wont be accessible.
