### PR TITLE
Answer with a 404 status code when the page is not found

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -21,7 +21,10 @@ class Pico {
 		else $file .= '.txt';
 
 		if(file_exists($file)) $content = file_get_contents($file);
-		else $content = file_get_contents(CONTENT_DIR .'404.txt');
+		else {
+			$content = file_get_contents(CONTENT_DIR .'404.txt');
+			header($_SERVER['SERVER_PROTOCOL'].' 404 Not Found');
+		}
 
 		$meta = $this->read_file_meta($content);
 		$content = preg_replace('#/\*.+?\*/#s', '', $content); // Remove comments and meta


### PR DESCRIPTION
When the page was not found in addition to rendering the 404.txt page, the server should answer with a 404 status code instead of 200
