### PR TITLE
Adding support for a {{ snippet }} tag

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -50,12 +50,34 @@ class Pico {
 
 	function parse_content($content)
 	{
+		$content = $this->parse_snippets($content);
 		$content = str_replace('%base_url%', $this->base_url(), $content);
 		$content = Markdown($content);
 
 		return $content;
 	}
+	function parse_snippets($content) 
+	{
+		$pattern  = '|\{\{ snippet (.+)\}\}|U'; // match things between '{{ snippet ' and '}}'
+		preg_match_all($pattern, $content, $matches);
+		$matchCount = isset($matches[0]) ? count($matches[0]) : 0;
+		if ($matchCount) {
+			foreach (range(0, $matchCount -1) as $index) {
+				$matched_str = $matches[0][$index];
+				$snippet = strtolower(trim($matches[1][$index]));
+				
+				// load the replacement text from file
+				$file = CONTENT_DIR . '/snippets/' . $snippet . '.txt';
+				$replacement = file_exists($file) ? file_get_contents($file) : '';
+							
+				// replace the {{ snippet snippet-name }} string with the loaded text
+				$content = str_replace($matched_str, $replacement, $content);				
+			}
+		}
 
+		return $content;
+	}
+	
 	function read_file_meta($content)
 	{
 		$headers = array(


### PR DESCRIPTION
In response to: https://github.com/gilbitron/Pico/issues/12

This commit would add support for a new tag, {{ snippet }}, which is available in content files (.txt files)

Example:

{{ snippet foo }} would replaced by the contents of CONTENT_DIR/snippets/foo.txt

If foo.txt does not exist in the snippets directory, the tag is replaced with an empty string.

Notes:
- this code "takes over" the snippets folder within the content directory. It might be nice instead to make a SNIPPET_DIR constant or a config option
- matches {{ snippet foo-bar }} but not {{snippet foo-bar}} 
- does not work in layouts, only in content files
- runs before the markdown parser
- does not sanitize the snippet name. this name is then passed to file_get_contents. (assuming templates can be trusted.)

I hope this is useful! I've not used GitHub before, so I hope I've done this correctly. Thanks so much for the great framework!

Cheers
George
