### PR TITLE
Add plugin hooks to customize page meta data

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -156,7 +156,7 @@ class Pico {
 		);
 
 		// Add support for custom headers by hooking into the headers array
-		$this->run_hooks('before_read_file_meata', array(&$headers));
+		$this->run_hooks('before_read_file_meta', array(&$headers));
 
 	 	foreach ($headers as $field => $regex){
 			if (preg_match('/^[ \t\/*#@]*' . preg_quote($regex, '/') . ':(.*)$/mi', $content, $match) && $match[1]){
@@ -240,7 +240,7 @@ class Pico {
 			);
 
 			// Extend the data provided with each page by hooking into the data array
-			$this->run_hooks('get_page_data', array(&$data, &$page_meta));
+			$this->run_hooks('get_page_data', array(&$data, $page_meta));
 
 			if($order_by == 'date'){
 				$sorted_pages[$page_meta['date'].$date_id] = $data;


### PR DESCRIPTION
This change would allow any developer the ability to easily add custom meta data to their pages. This pull request implements the following two plugin hooks:
- `before_read_file_meta` - Executed in the `read_file_meta` method directly after the initialization of the `$headers` array. The callback function will be passed the `$headers` array by reference for manipulation.
- `get_page_data` - Executed in the `get_pages` method for each page after the initialization of the `$pages` array. The callback function will be passed the `$data` array by reference as well as the `$page_meta` array for including extra meta data.
