### PR TITLE
Make get_files ignore dotfiles.

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -307,7 +307,7 @@ class Pico {
 	    $array_items = array();
 	    if($handle = opendir($directory)){
 	        while(false !== ($file = readdir($handle))){
-	            if($file != "." && $file != ".."){
+	            if(preg_match("/^(^\.)/", $file) === 0){
 	                if(is_dir($directory. "/" . $file)){
 	                    $array_items = array_merge($array_items, $this->get_files($directory. "/" . $file, $ext));
 	                } else {


### PR DESCRIPTION
This pull request changes `get_files` to ignore any file starting with `.` rather than only ignoring `.` and `..`. As it is, Pico will publish things like vim swap files.
