### PR TITLE
Make get_files() ignore hidden files and directories

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -307,7 +307,7 @@ class Pico {
 	    $array_items = array();
 	    if($handle = opendir($directory)){
 	        while(false !== ($file = readdir($handle))){
-	            if($file != "." && $file != ".."){
+	            if($file != "." && $file != ".." && substr($file,0,1) != "."){
 	                if(is_dir($directory. "/" . $file)){
 	                    $array_items = array_merge($array_items, $this->get_files($directory. "/" . $file, $ext));
 	                } else {


### PR DESCRIPTION
Ignore dot files and dot directories (so using svn don't break the site horribly)
