### PR TITLE
Get title automatically from first markdown title if not set in meta

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -164,6 +164,18 @@ class Pico {
 		}
 		
 		if($headers['date']) $headers['date_formatted'] = date($config['date_format'], strtotime($headers['date']));
+		
+		if(empty($headers['title'])){
+			preg_match('/^(.+?)[ ]*\n(=+|-+)[ ]*\n+/imu',$content,$matches);
+			if(count($matches) > 0){
+					$headers['title'] = $matches[1];
+			}else{
+				preg_match('/^\#{1}([^\#].*)$/imu',$content,$matches);
+				if(count($matches) > 0){
+					$headers['title'] = $matches[1];
+				}
+			}
+		}
 
 		return $headers;
 	}


### PR DESCRIPTION
This changeset allows read_file_meta to detect title from markdown itself by using markdowns syntax and seeking for H1 level title. This is done only if no title is set in meta itself. Supports both setext and atx style headers, setext is prioritized. 
