### PR TITLE
Move the code that loads the config so that it gets loaded earlier.

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -23,6 +23,10 @@ class Pico {
 		$this->load_plugins();
 		$this->run_hooks('plugins_loaded');
 		
+		// Load the settings
+		$settings = $this->get_config();
+		$this->run_hooks('config_loaded', array(&$settings));
+
 		// Get request url and script url
 		$url = '';
 		$request_url = (isset($_SERVER['REQUEST_URI'])) ? $_SERVER['REQUEST_URI'] : '';
@@ -51,10 +55,6 @@ class Pico {
 			$this->run_hooks('after_404_load_content', array(&$file, &$content));
 		}
 		$this->run_hooks('after_load_content', array(&$file, &$content));
-		
-		// Load the settings
-		$settings = $this->get_config();
-		$this->run_hooks('config_loaded', array(&$settings));
 
 		$meta = $this->read_file_meta($content);
 		$this->run_hooks('file_meta', array(&$meta));


### PR DESCRIPTION
This moves the config loading so that it takes place earlier. It makes the config values available in hooks that previously took place before the config was loaded.

The hooks that will now have access to config values are:
- request_url
- before_load_content
- before_404_load_content
- after_404_load_content
- after_load_content
