### PR TITLE
Allow custom layouts to be set in page meta. From the @pomaxa fork.

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -99,7 +99,19 @@ class Pico {
 			'is_front_page' => $url ? false : true,
 		);
 		$this->run_hooks('before_render', array(&$twig_vars, &$twig));
-		$output = $twig->render('index.html', $twig_vars);
+		// use layout or index
+		if (isset($meta['layout'])) {
+			$layout = $meta['layout'];
+			$ext = pathinfo($meta['layout'], PATHINFO_EXTENSION);
+			$layout .= (empty($ext)) ? '.html' : '';
+
+			if (file_exists(THEMES_DIR . $settings['theme'] . '/' . $layout) == false) {
+				$layout = 'index.html';
+			}
+		} else {
+			$layout = 'index.html';
+		}
+		$output = $twig->render($layout, $twig_vars);
 		$this->run_hooks('after_render', array(&$output));
 		echo $output;
 	}
@@ -151,9 +163,10 @@ class Pico {
 		$headers = array(
 			'title'       	=> 'Title',
 			'description' 	=> 'Description',
-			'author' 		=> 'Author',
-			'date' 			=> 'Date',
-			'robots'     	=> 'Robots'
+			'author' 	=> 'Author',
+			'date' 		=> 'Date',
+			'robots'     	=> 'Robots',
+			'layout'	=> 'Layout'
 		);
 
 		// Add support for custom headers by hooking into the headers array


### PR DESCRIPTION
Now you can do this:

```
/*
Title: I Love Kittens
Author: James Doyle
Layout: post
*/
```

This will load the `post.html` file from your chosen theme. If the `Layout` key was absent it would just fallback to the `index.html` file.

Taken from @pomaxa's fork!

This feature is in a couple other forks and I believe it is strongly needed.
