### PR TITLE
Added before_parse_content plugin trigger

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -58,8 +58,11 @@ class Pico {
 
 		$meta = $this->read_file_meta($content);
 		$this->run_hooks('file_meta', array(&$meta));
+                
+		$this->run_hooks('before_parse_content', array(&$content));
 		$content = $this->parse_content($content);
-		$this->run_hooks('content_parsed', array(&$content));
+		$this->run_hooks('after_parse_content', array(&$content));
+		$this->run_hooks('content_parsed', array(&$content)); // Backwards compatibility
 		
 		// Get all the pages
 		$pages = $this->get_pages($settings['base_url'], $settings['pages_order_by'], $settings['pages_order'], $settings['excerpt_length']);

--- a/plugins/pico_plugin.php
+++ b/plugins/pico_plugin.php
@@ -54,7 +54,12 @@ class Pico_Plugin {
 		
 	}
 	
-	public function content_parsed(&$content)
+	public function before_parse_content(&$content)
+	{
+		
+	}
+	
+	public function after_parse_content(&$content)
 	{
 		
 	}


### PR DESCRIPTION
The `before_parse_content` is useful to modify the Markdown content before it is converted to HTML.

In some cases this can be done using `after_load_content` trigger. However that trigger is called before loading the config and meta, making it impossible to modify the content based on any settings.

Consistently the `content_parsed` trigger is renamed to `after_parse_content`. To retain B.C. the `content_parsed` method is still called.
