### PR TITLE
[BUGFIX] load config and call hook before the other hooks

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -22,7 +22,11 @@ class Pico {
 		// Load plugins
 		$this->load_plugins();
 		$this->run_hooks('plugins_loaded');
-		
+
+		// Load the settings
+		$settings = $this->get_config();
+		$this->run_hooks('config_loaded', array(&$settings));
+
 		// Get request url and script url
 		$url = '';
 		$request_url = (isset($_SERVER['REQUEST_URI'])) ? $_SERVER['REQUEST_URI'] : '';
@@ -51,10 +55,6 @@ class Pico {
 			$this->run_hooks('after_404_load_content', array(&$file, &$content));
 		}
 		$this->run_hooks('after_load_content', array(&$file, &$content));
-		
-		// Load the settings
-		$settings = $this->get_config();
-		$this->run_hooks('config_loaded', array(&$settings));
 
 		$meta = $this->read_file_meta($content);
 		$this->run_hooks('file_meta', array(&$meta));


### PR DESCRIPTION
this bugfix is very important, because other hooks like "after_load_content" can not use the config.
