### PR TITLE
Change limit_words to only show ellipsis when word count exceeds max

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -342,7 +342,9 @@ class Pico {
 	private function limit_words($string, $word_limit)
 	{
 		$words = explode(' ',$string);
-		return trim(implode(' ', array_splice($words, 0, $word_limit))) .'...';
+		$excerpt = trim(implode(' ', array_splice($words, 0, $word_limit)));
+		if(count($words) > $word_limit) $excerpt .= '&hellip;';
+		return $excerpt;
 	}
 
 }


### PR DESCRIPTION
Hi there,
I have changed the limit_words function to use a real ellipsis instead of three dots and to only append them when the word count exceeds the word count specified in the parameters.
