### PR TITLE
behavior of file path definition on file inexistance rather than directory existance

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -38,13 +38,13 @@ class Pico {
 		$this->run_hooks('request_url', array(&$url));
 
 		// Get the file path
-		if($url) $file = CONTENT_DIR . $url;
-		else $file = CONTENT_DIR .'index';
+		if(!$url) $file = CONTENT_DIR .'index'. CONTENT_EXT;
+		else {
+			$file = CONTENT_DIR . $url .'/index'. CONTENT_EXT;
+			if(!is_file($file)) $file = CONTENT_DIR . $url . CONTENT_EXT;
+		}
 
 		// Load the file
-		if(is_dir($file)) $file = CONTENT_DIR . $url .'/index'. CONTENT_EXT;
-		else $file .= CONTENT_EXT;
-
 		$this->run_hooks('before_load_content', array(&$file));
 		if(file_exists($file)){
 			$content = file_get_contents($file);


### PR DESCRIPTION
For now when calling `foo/bar` the system use immediately `foo/bar/index.md` if `foo/bar/` directory exists.
Make more sense to do that instead if the file `foo/bar/index.md` exists.

This allow to have a directory with the same name next to a page file, adding a choice regarding files organization :

    content/
        bar/
            index.md
        foo/
        foo.md

May be usefull for instance in [Pages Images plugin](https://github.com/nliautaud/pico-pages-images#files-location).