### PR TITLE
Update pico.php

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -247,6 +247,9 @@ class Pico {
 				'date_formatted' => isset($page_meta['date']) ? date($config['date_format'], strtotime($page_meta['date'])) : '',
 				'content' => $page_content,
 				'excerpt' => $this->limit_words(strip_tags($page_content), $excerpt_length)
+				//this addition allows the 'description' meta to be picked up in content areas... specifically to replace 'excerpt'
+				'description' => isset($page_meta['description']) ? $page_meta['description'] : '',
+
 			);
 
 			// Extend the data provided with each page by hooking into the data array


### PR DESCRIPTION
Adding:   
     'description' => isset($page_meta['description']) ? $page_meta['description'] : '',
 to:    
     $data=array  

allows for use of the description meta in place of the excerpt.