### PR TITLE
Changes to the `pages` variable

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -239,15 +239,10 @@ class Pico {
 			$url = str_replace(CONTENT_DIR, $base_url .'/', $page);
 			$url = str_replace('index'. CONTENT_EXT, '', $url);
 			$url = str_replace(CONTENT_EXT, '', $url);
-			$data = array(
-				'title' => isset($page_meta['title']) ? $page_meta['title'] : '',
-				'url' => $url,
-				'author' => isset($page_meta['author']) ? $page_meta['author'] : '',
-				'date' => isset($page_meta['date']) ? $page_meta['date'] : '',
-				'date_formatted' => isset($page_meta['date']) ? date($config['date_format'], strtotime($page_meta['date'])) : '',
-				'content' => $page_content,
-				'excerpt' => $this->limit_words(strip_tags($page_content), $excerpt_length)
-			);
+			$data = $page_meta;
+			$data['url'] = $url;
+			$data['content'] = $page_content;
+			$data['excerpt'] = $this->limit_words(strip_tags($page_content), $excerpt_length);
 
 			// Extend the data provided with each page by hooking into the data array
 			$this->run_hooks('get_page_data', array(&$data, $page_meta));

--- a/lib/pico.php
+++ b/lib/pico.php
@@ -232,6 +232,13 @@ class Pico {
 				unset($pages[$key]);
 				continue;
 			}			
+
+			// Ignore files starting with an underscore
+			if (substr(basename($page), 0, 1) == '_') {
+				unset($pages[$key]);
+				continue;
+			}
+
 			// Get title and format $page
 			$page_content = file_get_contents($page);
 			$page_meta = $this->read_file_meta($page_content);


### PR DESCRIPTION
There's 2 commits for 2 different things related to the `pages` variable in the template:

- Ignoring files that start with an underscore (common practice in flat-file systems)
- Make custom meta headers available (the ones added using the `before_read_file_meta` hook, as explained in the docs)

So if you do

```php
public function before_read_file_meta(&$headers)
{
	$headers['layout'] = 'Layout';
}
```

You get `{{ page.layout }}` while iterating `pages` as well as in `{{ meta.layout }}`.