### PR TITLE
Don't remove all comments while parse content

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -136,7 +136,7 @@ class Pico {
 	 */
 	protected function parse_content($content)
 	{
-		$content = preg_replace('#/\*.+?\*/#s', '', $content); // Remove comments and meta
+		$content = preg_replace('#/\*.+?\*/#s', '', $content, 1); // Remove comments and meta
 		$content = str_replace('%base_url%', $this->base_url(), $content);
 		$content = MarkdownExtra::defaultTransform($content);
 

--- a/lib/pico.php
+++ b/lib/pico.php
@@ -136,7 +136,7 @@ class Pico {
 	 */
 	protected function parse_content($content)
 	{
-		$content = preg_replace('#/\*.+?\*/#s', '', $content, 1); // Remove comments and meta
+		$content = preg_replace('#/\*.+?\*/#s', '', $content, 1); // Remove first comment (with meta)
 		$content = str_replace('%base_url%', $this->base_url(), $content);
 		$content = MarkdownExtra::defaultTransform($content);
 


### PR DESCRIPTION
There is already openned bug #67, #130 (pico removes ALL comments from the content).
This patch fix it, by removing only first comment-block (with meta info).

Now, pico.php during parsing remove all `/* such comment blocks */`
prons?
* you can use such comments for private comments, which will see nobody except you 

cons?
* it's undeclared ability, coz original Markdown language (i.e. php-markdown parser) hasn't syntax-abillity
 for comments like in other langs, and people hope so. 

So, if someone often uses pivate-comments, he can do something like `[c]:с (some comment)`, which is syntactically correct. But when people post `code` with `/* doc-comments */`, they face trouble with which they can not do anything.

Or, it will be good to be documented in Doc :)