### PR TITLE
Removed space character between /*

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -37,7 +37,7 @@ Text files are marked up using [Markdown](http://daringfireball.net/projects/mar
 
 At the top of text files you can place a block comment and specify certain attributes of the page. For example:
 
-	/ *
+	/*
 	Title: Welcome
 	Description: This description will go in the meta description tag
 	Author: Joe Bloggs


### PR DESCRIPTION
On the start page of the example content, there was a space between `/*` in a sample markdown code.
