### PR TITLE
Add missing php end tag

### DIFF
--- a/index.php
+++ b/index.php
@@ -11,3 +11,5 @@ define('CACHE_DIR', LIB_DIR .'cache/');
 require(ROOT_DIR .'vendor/autoload.php');
 require(LIB_DIR .'pico.php');
 $pico = new Pico();
+
+?>


### PR DESCRIPTION
Just downloaded Pico and got an server error. Fixed it by adding the php end tag that went missing in commit 145915346cefb0443f68ad7709846c8d289984fd
