### PR TITLE
Localize date meta

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -173,7 +173,7 @@ class Pico {
 			}
 		}
 		
-		if(isset($headers['date'])) $headers['date_formatted'] = strftime($config['date_format'], strtotime($headers['date']));
+		if(isset($headers['date'])) $headers['date_formatted'] = utf8_encode(strftime($config['date_format'], strtotime($headers['date'])));
 
 		return $headers;
 	}
@@ -244,7 +244,7 @@ class Pico {
 				'url' => $url,
 				'author' => isset($page_meta['author']) ? $page_meta['author'] : '',
 				'date' => isset($page_meta['date']) ? $page_meta['date'] : '',
-				'date_formatted' => isset($page_meta['date']) ? strftime($config['date_format'], strtotime($page_meta['date'])) : '',
+				'date_formatted' => isset($page_meta['date']) ? utf8_encode(strftime($config['date_format'], strtotime($page_meta['date']))) : '',
 				'content' => $page_content,
 				'excerpt' => $this->limit_words(strip_tags($page_content), $excerpt_length)
 			);

--- a/lib/pico.php
+++ b/lib/pico.php
@@ -173,7 +173,7 @@ class Pico {
 			}
 		}
 		
-		if(isset($headers['date'])) $headers['date_formatted'] = date($config['date_format'], strtotime($headers['date']));
+		if(isset($headers['date'])) $headers['date_formatted'] = strftime($config['date_format'], strtotime($headers['date']));
 
 		return $headers;
 	}
@@ -244,7 +244,7 @@ class Pico {
 				'url' => $url,
 				'author' => isset($page_meta['author']) ? $page_meta['author'] : '',
 				'date' => isset($page_meta['date']) ? $page_meta['date'] : '',
-				'date_formatted' => isset($page_meta['date']) ? date($config['date_format'], strtotime($page_meta['date'])) : '',
+				'date_formatted' => isset($page_meta['date']) ? strftime($config['date_format'], strtotime($page_meta['date'])) : '',
 				'content' => $page_content,
 				'excerpt' => $this->limit_words(strip_tags($page_content), $excerpt_length)
 			);


### PR DESCRIPTION
Use strftime() instead of date() so that non-english websites can
display the date meta in their locale. The locale can be set with
`setLocale(LC_ALL, 'YOURLOCALE')`.
Please note that this changes the date format.
More information: http://php.net/strftime