### PR TITLE
made ssl check compatible with nginx & php5-fcgi

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -309,7 +309,7 @@ class Pico {
 	protected function get_protocol()
 	{
 		$protocol = 'http';
-		if(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off'){
+		if(isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) === 'on'){
 			$protocol = 'https';
 		}
 		return $protocol;


### PR DESCRIPTION
ssl check worked wrong on php5-fcgi (5.3.10-1ubuntu3.10) in nginx environment. strtolower alone would have fixed the problem as well.