### PR TITLE
Update pico.php

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -327,6 +327,9 @@ class Pico {
 	    $array_items = array();
 	    if($handle = opendir($directory)){
 	        while(false !== ($file = readdir($handle))){
+	            if(in_array(substr($file, -1), array('~', '#'))){
+	            	continue;
+	            }
 	            if(preg_match("/^(^\.)/", $file) === 0){
 	                if(is_dir($directory. "/" . $file)){
 	                    $array_items = array_merge($array_items, $this->get_files($directory. "/" . $file, $ext));


### PR DESCRIPTION
Added ignore for tmp file extensions in the get_files() method. When editing plugins with emacs, the get_files() method also grabs the temp files, which leads to a "Can't redclare class [PluginName]" error.

Side note: Would these arrays be better in a property (ala DRY)?