### PR TITLE
HTTPS fix

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -309,7 +309,7 @@ class Pico {
 	protected function get_protocol()
 	{
 		$protocol = 'http';
-		if(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off'){
+		if(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != ''){
 			$protocol = 'https';
 		}
 		return $protocol;


### PR DESCRIPTION
Some web server returns a $_SERVER['HTTPS'] = 'no value' for non https connections

ie. nginx-1.7.0 with php5-fpm, causing all navigation links to link to https when on http version of site

https://stackoverflow.com/questions/1175096/how-to-find-out-if-you-are-using-https-without-serverhttps