### PR TITLE
(minor) Reformatted config.php to make configuration more obvious

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,23 +1,64 @@
 <?php 
+/**
+ * Pico Configuration
+ *
+ * This is the configuration file for Pico. It comes loaded with the 
+ *  default values, which can be found in the get_config() method of
+ *  the Pico class (lib/pico.php).
+ *
+ * @author Gilbert Pellegrom
+ * @link http://picocms.org
+ * @license http://opensource.org/licenses/MIT
+ * @version 0.8
+ */
 
 /*
-// Override any of the default settings below:
+ * Site title
+ */
+$config['site_title'] = 'Pico';
 
-$config['site_title'] = 'Pico';			// Site title
-$config['base_url'] = ''; 				// Override base URL (e.g. http://example.com)
-$config['theme'] = 'default'; 			// Set the theme (defaults to "default")
-$config['date_format'] = 'jS M Y';		// Set the PHP date format
-$config['twig_config'] = array(			// Twig settings
-	'cache' => false,					// To enable Twig caching change this to CACHE_DIR
-	'autoescape' => false,				// Autoescape Twig vars
-	'debug' => false					// Enable Twig debug
+/*
+ * Override base URL (e.g. http://example.com)
+ */
+$config['base_url'] = '';
+
+// Set the theme (defaults to "default")
+$config['theme'] = 'default';
+
+// Set the PHP date format
+$config['date_format'] = 'jS M Y';
+
+/*
+ * Twig settings
+ * To enable Twig caching change the value of 'cache' to CACHE_DIR
+ * Autoescape Twig vars
+ * Enable Twig debug
+ */
+$config['twig_config'] = array(			
+	'cache' => false,
+	'autoescape' => false,
+	'debug' => false
 );
-$config['pages_order_by'] = 'alpha';	// Order pages by "alpha" or "date"
-$config['pages_order'] = 'asc';			// Order pages "asc" or "desc"
-$config['excerpt_length'] = 50;			// The pages excerpt length (in words)
 
-// To add a custom config setting:
+/*
+ * Order pages by "alpha" or "date"
+ */
+$config['pages_order_by'] = 'alpha';	 
 
-$config['custom_setting'] = 'Hello'; 	// Can be accessed by {{ config.custom_setting }} in a theme
+/*
+ * Order pages "asc" or "desc"
+ */
+$config['pages_order'] = 'asc';			
 
-*/
+/*
+ * The pages excerpt length (in words)
+ */
+$config['excerpt_length'] = 50;			
+
+/*
+ * Custom configuration settings can be added, too.
+ * The following example can be accessed with the
+ * Twig variable {{ config.custom_setting }} in a theme
+ */
+
+// $config['custom_setting'] = 'Hello'; 	


### PR DESCRIPTION
Minor change to layout in config.php to actually use the values present, and changed the style of comments to make the behavior more immediately obvious, particularly for non-developers to use. Addresses #195.