### PR TITLE
Fix typos

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -286,7 +286,7 @@ Layout: 2col
 		  <p>You will then be able to access this value via the <code>{{ meta.layout }}</code> template variable.</p>
 	      <hr>
 	      <h3 id="contribute">Contribute</h3>
-	      <p>Help make Pico better by checking out <a href="https://github.com/gilbitron/Pico">the GitHub repoistory</a> and submitting pull requests. If you find a bug
+	      <p>Help make Pico better by checking out <a href="https://github.com/gilbitron/Pico">the GitHub repository</a> and submitting pull requests. If you find a bug
 	      please report it on <a href="https://github.com/gilbitron/Pico/issues">the issues page</a>.</p>
 	      <hr>
       </div>

--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
         </div>
         <div class="one-third box last"> <i class="icon-database special"></i>
           <h3>No Database</h3>
-          <p>Pico is a "flat file" CMS, meaning no database woe's, no MySQL queries, nothing.</p>
+          <p>Pico is a "flat file" CMS, meaning no database woes, no MySQL queries, nothing.</p>
         </div>
         <div class="clear"></div>
         <br />


### PR DESCRIPTION
“repoistory” —> “repository”
“woe's” —> “woes”