### PR TITLE
Define missing content directory

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,6 +1,7 @@
 <?php
 
 define('ROOT_DIR', realpath(dirname(__FILE__)) .'/');
+define('CONTENT_DIR', ROOT_DIR .'content-sample/');
 define('CONTENT_EXT', '.md');
 define('LIB_DIR', ROOT_DIR .'lib/');
 define('PLUGINS_DIR', ROOT_DIR .'plugins/');


### PR DESCRIPTION
Using the editor plugin after this file was updated causes errors (possibly other places as well) 
Fixed by re-defining the content directory...