### PR TITLE
fix date_formatted issue

### DIFF
--- a/config.php.template
+++ b/config.php.template
@@ -1,8 +1,8 @@
-<?php 
+<?php
 /**
  * Pico Configuration
  *
- *  This is the configuration file for Pico. It comes loaded with the 
+ *  This is the configuration file for Pico. It comes loaded with the
  *  default values, which can be found in the get_config() method of
  *  the Pico class (lib/pico.php).
  *
@@ -11,7 +11,7 @@
  * @license http://opensource.org/licenses/MIT
  * @version 0.9
  *
- * To override any of the default settings below, uncomment the line, 
+ * To override any of the default settings below, uncomment the line,
  * make and save the changes, then rename this file to `config.php`
  */
 
@@ -26,15 +26,15 @@
  */
 // $config['theme'] = 'default';                // Set the theme (defaults to "default")
 // $config['twig_config'] = array(              // Twig settings
-//	'cache' => false,	                // To enable Twig caching change this to CACHE_DIR
-//	'autoescape' => false,                  // Autoescape Twig vars
-//	'debug' => false                        // Enable Twig debug
+//	'cache' => false,	                        // To enable Twig caching change this to CACHE_DIR
+//	'autoescape' => false,                      // Autoescape Twig vars
+//	'debug' => false                            // Enable Twig debug
 // );
 
 /*
  * CONTENT
  */
-// $config['date_format'] = 'jS M Y';             // Set the PHP date format as described here: http://php.net/manual/en/function.strftime.php
+// $config['date_format'] = '%D %T';             // Set the PHP date format as described here: http://php.net/manual/en/function.strftime.php
 // $config['pages_order_by'] = 'alpha';           // Order pages by "alpha" or "date"
 // $config['pages_order'] = 'asc';                // Order pages "asc" or "desc"
 // $config['excerpt_length'] = 50;                // The pages excerpt length (in words)

--- a/lib/pico.php
+++ b/lib/pico.php
@@ -1,5 +1,4 @@
 <?php
-use \ParsedownExtra;
 
 /**
  * Pico
@@ -63,7 +62,7 @@ class Pico {
 		$content = $this->parse_content($content);
 		$this->run_hooks('after_parse_content', array(&$content));
 		$this->run_hooks('content_parsed', array(&$content)); // Depreciated @ v0.8
-		
+
 		// Get all the pages
 		$pages = $this->get_pages($settings['base_url'], $settings['pages_order_by'], $settings['pages_order'], $settings['excerpt_length']);
 		$prev_page = array();
@@ -108,7 +107,7 @@ class Pico {
 		$this->run_hooks('after_render', array(&$output));
 		echo $output;
 	}
-	
+
 	/**
 	 * Load any plugins
 	 */
@@ -152,7 +151,7 @@ class Pico {
 	protected function read_file_meta($content)
 	{
 		global $config;
-		
+
 		$headers = array(
 			'title'       	=> 'Title',
 			'description' 	=> 'Description',
@@ -172,7 +171,7 @@ class Pico {
 				$headers[ $field ] = '';
 			}
 		}
-		
+
 		if(isset($headers['date'])) $headers['date_formatted'] = utf8_encode(strftime($config['date_format'], strtotime($headers['date'])));
 
 		return $headers;
@@ -192,7 +191,7 @@ class Pico {
 			'site_title' => 'Pico',
 			'base_url' => $this->base_url(),
 			'theme' => 'default',
-			'date_format' => 'jS M Y',
+			'date_format' => '%D %T',
 			'twig_config' => array('cache' => false, 'autoescape' => false, 'debug' => false),
 			'pages_order_by' => 'alpha',
 			'pages_order' => 'asc',
@@ -205,7 +204,7 @@ class Pico {
 
 		return $config;
 	}
-	
+
 	/**
 	 * Get a list of pages
 	 *
@@ -217,7 +216,7 @@ class Pico {
 	protected function get_pages($base_url, $order_by = 'alpha', $order = 'asc', $excerpt_length = 50)
 	{
 		global $config;
-		
+
 		$pages = $this->get_files($config['content_dir'], CONTENT_EXT);
 		$sorted_pages = array();
 		$date_id = 0;
@@ -232,7 +231,7 @@ class Pico {
 			if (in_array(substr($page, -1), array('~','#'))) {
 				unset($pages[$key]);
 				continue;
-			}			
+			}
 			// Get title and format $page
 			$page_content = file_get_contents($page);
 			$page_meta = $this->read_file_meta($page_content);
@@ -262,13 +261,13 @@ class Pico {
 			}
 			else $sorted_pages[$page] = $data;
 		}
-		
+
 		if($order == 'desc') krsort($sorted_pages);
 		else ksort($sorted_pages);
-		
+
 		return $sorted_pages;
 	}
-	
+
 	/**
 	 * Processes any hooks and runs them
 	 *
@@ -318,14 +317,14 @@ class Pico {
 		}
 		return $protocol;
 	}
-	     
+
 	/**
 	 * Helper function to recusively get all files in a directory
 	 *
 	 * @param string $directory start directory
 	 * @param string $ext optional limit to file extensions
 	 * @return array the matched files
-	 */ 
+	 */
 	protected function get_files($directory, $ext = '')
 	{
 	    $array_items = array();
@@ -347,14 +346,14 @@ class Pico {
 	    }
 	    return $array_items;
 	}
-	
+
 	/**
 	 * Helper function to limit the words in a string
 	 *
 	 * @param string $string the given string
 	 * @param int $word_limit the number of words to limit to
 	 * @return string the limited string
-	 */ 
+	 */
 	protected function limit_words($string, $word_limit)
 	{
 		$words = explode(' ',$string);


### PR DESCRIPTION
Issue #204

The proper strftime notation was not used in `pico.php` or `config.php.template` causing the date to not be displayed when using the twig variable `{{ page.date_formatted }}` as is the case when using Pico's blog template. 

Solved by changing the default formatting string.