### PR TITLE
Bug fix : If the article of the same "title" there are a plurality , I show the "current_page" is different article file.

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -80,8 +80,9 @@ class Pico
         $prev_page = array();
         $current_page = array();
         $next_page = array();
+        $checkurl = $settings['base_url'] . "/" . $url;
         while ($current_page = current($pages)) {
-            if ((isset($meta['title'])) && ($meta['title'] == $current_page['title'])) {
+            if ($current_page['url'] == $checkurl || $current_page['url'] == $checkurl . "/" ) {
                 break;
             }
             next($pages);


### PR DESCRIPTION
The search process of "current_page" , in the "title" but changed to use the page URL.