### PR TITLE
Use scandir instead of opendir to ensure alphabetical order.

### DIFF
--- a/lib/pico.php
+++ b/lib/pico.php
@@ -359,8 +359,8 @@ class Pico
     protected function get_files($directory, $ext = '')
     {
         $array_items = array();
-        if ($handle = opendir($directory)) {
-            while (false !== ($file = readdir($handle))) {
+        if ($files = scandir($directory)) {
+            foreach ($files as $file) {
                 if (in_array(substr($file, -1), array('~', '#'))) {
                     continue;
                 }
@@ -375,7 +375,6 @@ class Pico
                     }
                 }
             }
-            closedir($handle);
         }
 
         return $array_items;


### PR DESCRIPTION
`opendir` doesn't ensure returning the directory's entries in alphabetical order for `readdir` which causes some plugin dependencies to not work - many plugins (e.g. `nav_sort`) have a dependency on `adv_meta`, for instance. This pull request replaces it with `scandir` which does exactly that and ensures the plugin dependencies work on every system.

Here is a stackoverflow:
http://stackoverflow.com/a/541539/1527244