### PR TITLE
Support an additional folder for 'blog posts'

### DIFF
--- a/config/config.php.template
+++ b/config/config.php.template
@@ -41,6 +41,14 @@
 // $config['content_dir'] = 'content-sample/';    // Content directory
 
 /*
+ * BLOG POSTS
+ */
+
+$config['blog_dir'] = 'content-posts/';         // Blog post directory
+$config['blog_url'] = 'blog';                   // Route for blog content, appended to base url
+                                                // when parsing blog URIs
+ 
+/*
  * TIMEZONE
  */
 // date_default_timezone_set('UTC');              // Timezone may be reqired by your php install


### PR DESCRIPTION
Hi,

I've just implemented PicoCMS. I've really enjoyed the simplicity in setting it up and it's very nearly perfect for my current requirements.

I really wanted a feature for separating out static content and blog posts. Blog posts can be numerous and I really wanted the flexibility of storing them in a separate location. Additionally I'd enjoy the benefit of parsing them separately from static pages from within my theme templates.

As a first time contributor, I welcome your feedback. If the changes interest you but need further work, I'm happy to take that on board and revise my fork. Otherwise, if this is not something you wish to incorporate into PicoCMS, I'll understand the rejection.

Best wishes
Dan
aka biscuitNinja