### PR TITLE
Automated build release uploading with travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: php
+php:
+  - 5.4
+
+script:
+  - composer install
+  - tar -czf pico.tar.gz .htaccess README.md changelog.txt composer.json composer.lock config content-sample index.php lib license.txt plugins themes vendor
+
+deploy:
+  provider: releases
+  api_key: ${GITHUB_OAUTH_TOKEN}
+  file: pico.tar.gz
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
As discussed in #268, this is a travis file suitable for building a release tarball.

Administratives steps required for making this run are:
* Adding travis as a service for the repository,
* Setting up an env variable "GITHUB_OAUTH_TOKEN" in the [repository settings](http://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings).
* Tagging a version to trigger the build.