### PR TITLE
Update plugins page 

### DIFF
--- a/plugins.html
+++ b/plugins.html
@@ -1,99 +1,121 @@
 ---
 layout: default
-title: Plugins
-headline: Pico Plugins
+title: Add-Ons
+headline: Pico Plugins &amp; Themes
 description: |
     Below are some plugins which extend the functionality of Pico and make it even more awesome.<br />
     Want to make a plugin? See [the docs](docs.html#plugins).
 nav: 4
 ---
+<h1>Plugins</h1>
+<div class="toggle">
+    <h4 class="title">... for Pico 1.0+</h4>
+    <div class="togglebox">
+        <div class="one-third">
+            <h3>Tags</h3>
+            <p>Provides tags functionality for Pico.</p>
+            <p><a href="https://github.com/PontusHorn/Pico-Tags" class="button red">Download</a></p>
+        </div>
+        <div class="one-third ">
+            <h3>Editor</h3>
+            <p>Markdown editor and file manager for Pico.</p>
+            <p><a href="https://github.com/theshka/Pico-Editor-Plugin" class="button red">Download</a></p>
+        </div>
+        <div class="one-third last">
+            <h3>Pico GAnalytics</h3>
+            <p>Google Analytics for Pico with basic options. </p>
+            <p><a href="https://github.com/bricebou/pico_ganalytics" class="button red">Download</a></p>
+        </div>
+        <div class="clear"></div><br />
 
-<h1>Pico 1.0 </h1>
-<div class="one-third">
-    <h3>Tags</h3>
-    <p>Provides tags functionality for Pico.</p>
-    <p><a href="https://github.com/PontusHorn/Pico-Tags" class="button red">Download</a></p>
+        <div class="one-third">
+            <h3>Pico GitHub Activity</h3>
+            <p>Your GitHub public activity feed.</p>
+            <p><a href="https://github.com/theshka/pico_githubactivity" class="button red">Download</a></p>
+        </div>
+    </div>
 </div>
-<div class="one-third ">
-    <h3>Editor</h3>
-    <p>Markdown editor and file manager for Pico.</p>
-    <p><a href="https://github.com/theshka/Pico-Editor-Plugin" class="button red">Download</a></p>
-</div>
-<div class="one-third last">
-    <h3>Pico GAnalytics</h3>
-    <p>Gooogle Analytics for Pico with basic options. </p>
-    <p><a href="https://github.com/bricebou/pico_ganalytics" class="button red">Download</a></p>
-</div>
-<div class="clear"></div><br />
 
-<div class="one-third">
-    <h3>Pico GitHub Activity</h3>
-    <p>Your GitHub public activity feed.</p>
-    <p><a href="https://github.com/theshka/pico_githubactivity" class="button red">Download</a></p>
-</div>
-<div class="clear"></div><br />
+<div class="toggle">
+    <h4 class="title">... for Pico 0.X</h4>
+    <div class="togglebox">
+        <div class="one-third">
+            <h3>Pagination</h3>
+            <p>Provides basic pagination for Pico.</p>
+            <p><a href="https://github.com/rewdy/Pico-Pagination" class="button red">Download</a></p>
+        </div>
+        <div class="one-third">
+            <h3>Slider</h3>
+            <p>Create sliders (image lists) inside Pico.</p>
+            <p><a href="https://github.com/james2doyle/pico_slider" class="button red">Download</a></p>
+        </div>
+        <div class="one-third last">
+            <h3>Sitemap</h3>
+            <p>Pico plugin to generate an XML sitemap.</p>
+            <p><a href="https://github.com/Techn0tic/Pico_Sitemap" class="button red">Download</a></p>
+        </div>
+        <div class="clear"></div><br />
 
-<h1>Pico 0.X </h1>
-<div class="one-third">
-    <h3>Pagination</h3>
-    <p>Provides basic pagination for Pico.</p>
-    <p><a href="https://github.com/rewdy/Pico-Pagination" class="button red">Download</a></p>
-</div>
-<div class="one-third">
-    <h3>Slider</h3>
-    <p>Create sliders (image lists) inside Pico.</p>
-    <p><a href="https://github.com/james2doyle/pico_slider" class="button red">Download</a></p>
-</div>
-<div class="one-third last">
-    <h3>Sitemap</h3>
-    <p>Pico plugin to generate an XML sitemap.</p>
-    <p><a href="https://github.com/Techn0tic/Pico_Sitemap" class="button red">Download</a></p>
-</div>
-<div class="clear"></div><br />
+        <div class="one-third">
+            <h3>Get Files By Name</h3>
+            <p>A Pico plugin to grab content by the filename.</p>
+            <p><a href="https://github.com/james2doyle/pico_get_by_filename" class="button red">Download</a></p>
+        </div>
+        <div class="one-third">
+            <h3>Advanced Meta</h3>
+            <p>A simple plugin to customize page meta.</p>
+            <p><a href="https://github.com/shawnsandy/adv-meta" class="button red">Download</a></p>
+        </div>
+        <div class="one-third last">
+            <h3>Private</h3>
+            <p>Provide authentication to keep your site private.</p>
+            <p><a href="https://github.com/jbleuzen/Pico-Private" class="button red">Download</a></p>
+        </div>
+        <div class="clear"></div><br />
 
-<div class="one-third">
-    <h3>Get Files By Name</h3>
-    <p>A Pico plugin to grab content by the filename.</p>
-    <p><a href="https://github.com/james2doyle/pico_get_by_filename" class="button red">Download</a></p>
-</div>
-<div class="one-third">
-    <h3>Advanced Meta</h3>
-    <p>A simple plugin to customize page meta.</p>
-    <p><a href="https://github.com/shawnsandy/adv-meta" class="button red">Download</a></p>
-</div>
-<div class="one-third last">
-    <h3>Private</h3>
-    <p>Provide authentication to keep your site private.</p>
-    <p><a href="https://github.com/jbleuzen/Pico-Private" class="button red">Download</a></p>
-</div>
-<div class="clear"></div><br />
+        <div class="one-third">
+            <h3>OpenGraph</h3>
+            <p>Adds OpenGraph to your Pico site.</p>
+            <p><a href="https://github.com/ahmet2106/pico-opengraph" class="button red">Download</a></p>
+        </div>
+        <div class="one-third">
+            <h3>Navigation</h3>
+            <p>Generates a better navigation for Pico.</p>
+            <p><a href="https://github.com/ahmet2106/pico-navigation" class="button red">Download</a></p>
+        </div>
+        <div class="one-third last">
+            <h3>RSS Feed</h3>
+            <p>Provides an RSS Feed for Pico.</p>
+            <p><a href="https://github.com/gilbitron/Pico-RSS-Plugin" class="button red">Download</a></p>
+        </div>
+        <div class="clear"></div><br />
 
-<div class="one-third">
-    <h3>OpenGraph</h3>
-    <p>Adds OpenGraph to your Pico site.</p>
-    <p><a href="https://github.com/ahmet2106/pico-opengraph" class="button red">Download</a></p>
+        <div class="one-third">
+            <h3>Draftin</h3>
+            <p>
+                This is a Pico plugin that integrates <a href="http://draftin.com" target="_blank">Draft</a> into Pico.
+                You can see a tutorial on how to use it on <a href="http://www.codeforest.net/pico-cms-and-draft" target="_blank">Codeforest</a>.
+            </p>
+            <p><a href="https://github.com/codeforest/pico_draft" class="button red">Download</a></p>
+        </div>
+        <div class="clear"></div><br />
+    </div>
 </div>
-<div class="one-third">
-    <h3>Navigation</h3>
-    <p>Generates a better navigation for Pico.</p>
-    <p><a href="https://github.com/ahmet2106/pico-navigation" class="button red">Download</a></p>
-</div>
-<div class="one-third last">
-    <h3>RSS Feed</h3>
-    <p>Provides an RSS Feed for Pico.</p>
-    <p><a href="https://github.com/gilbitron/Pico-RSS-Plugin" class="button red">Download</a></p>
-</div>
-<div class="clear"></div><br />
 
-<div class="one-third">
-    <h3>Draftin</h3>
-    <p>
-        This is a Pico plugin that integrates <a href="http://draftin.com" target="_blank">Draft</a> into Pico.
-        You can see a tutorial on how to use it on <a href="http://www.codeforest.net/pico-cms-and-draft" target="_blank">Codeforest</a>.
-    </p>
-    <p><a href="https://github.com/codeforest/pico_draft" class="button red">Download</a></p>
+<h1>Themes</h1>
+<div class="toggle">
+    <h4 class="title">... for Pico 1.0+</h4>
+    <div class="togglebox">
+        <div class="one-third">
+            <h3>NotePaper Theme</h3>
+            <p>
+                This theme is loosly based on the <a href="https://wordpress.org/themes/anarcho-notepad/">Anarcho Notepad</a> theme for Wordpres.
+            </p>
+            <p><a href="https://github.com/smcdougall/NotePaper" class="button red">Download</a></p>
+        </div>
+        <div class="clear"></div><br />
+    </div>
 </div>
-<div class="clear"></div><br />
 
-<p class="aligncenter">Have you created a plugin for Pico?
+<p class="aligncenter">Have you created a plugin or theme for Pico?
 <a href="{{ site.gh_project_url }}/wiki/Pico-Plugins">Add it to the wiki</a> and we'll put it up here.</p>


### PR DESCRIPTION
Change `plugins` title to `add-ons`, and list all plugins and themes for Pico 0.X and Pico 1.0+ using the same togglebox as cookbook. Demo: http://theshka.github.io/Pico/plugins.html