### PR TITLE
change Pico's default `index.php` to be compatible with `composer require picocms/pico`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Released: -
           (RFC 3986) in `Page::evaluateRequestUrl()`
 * [Fixed] #272: Encode URLs using `rawurlencode()` in `Pico::getPageUrl()`
 * [Fixed] #274: Prevent double slashes in `base_url`
+* [Fixed] #285: Make `index.php` work when installed as a composer dependency
 ```
 
 ### Version 1.0.0-beta.1

--- a/index.php
+++ b/index.php
@@ -1,6 +1,14 @@
 <?php
+
+$parent = '..' . DIRECTORY_SEPARATOR;
+set_include_path(
+    get_include_path() . PATH_SEPARATOR .
+    $parent . $parent . $parent . PATH_SEPARATOR .
+    '.'
+);
+
 // load dependencies
-require_once(__DIR__ . '/vendor/autoload.php');
+require_once('vendor/autoload.php');
 
 // instance Pico
 $pico = new Pico(

--- a/index.php
+++ b/index.php
@@ -1,14 +1,16 @@
 <?php
 
-$parent = '..' . DIRECTORY_SEPARATOR;
-set_include_path(
-    get_include_path() . PATH_SEPARATOR .
-    $parent . $parent . $parent . PATH_SEPARATOR .
-    '.'
-);
-
 // load dependencies
-require_once('vendor/autoload.php');
+if(is_file($f = __DIR__ . '/vendor/autoload.php')) {
+    // local composer install
+    require_once($f);
+} elseif(is_file($f = __DIR__ . '/../../../vendor/autoload.php')) {
+    // root composer install
+    require_once($f);
+} else {
+    // composer needs install...
+    die('Cannot find composer `/vendor/autoload.php` -- try `composer install`');
+}
 
 // instance Pico
 $pico = new Pico(


### PR DESCRIPTION
I'm installing Pico as a dependency of a project. But it is hardwired to load autoload.php from project root. It doesn't work when it is inside vendor/picocms.

I'm not sure if there is a better way to address this issue.

It fixes issue #285 