### PR TITLE
Catch YAML parse errors

### DIFF
--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -266,8 +266,8 @@ class Pico
      * meta headers, processes Markdown, does Twig processing and returns
      * the rendered contents.
      *
-     * @return string           rendered Pico contents
-     * @throws RuntimeException thrown when a not recoverable error occurs
+     * @return string    rendered Pico contents
+     * @throws Exception thrown when a not recoverable error occurs
      */
     public function run()
     {
@@ -760,9 +760,13 @@ class Pico
         $pattern = "/^(\/(\*)|---)[[:blank:]]*(?:\r)?\n"
             . "(.*?)(?:\r)?\n(?(2)\*\/|---)[[:blank:]]*(?:(?:\r)?\n|$)/s";
         if (preg_match($pattern, $rawContent, $rawMetaMatches)) {
-            $yamlParser = new \Symfony\Component\Yaml\Parser();
-            $meta = $yamlParser->parse($rawMetaMatches[3]);
-            $meta = array_change_key_case($meta, CASE_LOWER);
+            try {
+                $yamlParser = new \Symfony\Component\Yaml\Parser();
+                $meta = $yamlParser->parse($rawMetaMatches[3]);
+                $meta = array_change_key_case($meta, CASE_LOWER);
+            } catch (\Symfony\Component\Yaml\Exception\ParseException $e) {
+                $meta['YAML_ParseError'] = $e->getMessage();
+            }
 
             foreach ($headers as $fieldId => $fieldName) {
                 $fieldName = strtolower($fieldName);
@@ -960,6 +964,9 @@ class Pico
                 $rawContent = &$this->rawContent;
                 $meta = &$this->meta;
             }
+
+            // fallback to page id if page title is empty
+            $meta['title'] = (!empty($meta['title'])) ? $meta['title'] : $id;
 
             // build page data
             // title, description, author and date are assumed to be pretty basic data

--- a/themes/default/index.twig
+++ b/themes/default/index.twig
@@ -32,6 +32,15 @@
     </header>
 
     <section id="content">
+        {% if meta.YAML_ParseError %}
+            <div class="error">
+                <div class="inner">
+                    <h2>Invalid YAML Front Matter</h2>
+                    <p>{{ meta.YAML_ParseError }}</p>
+                </div>
+            </div>
+        {% endif %}
+
         <div class="inner">
             {{ content }}
         </div>

--- a/themes/default/style.css
+++ b/themes/default/style.css
@@ -119,7 +119,6 @@ a:hover, a:active {
 }
 
 h1, h2, h3, h4, h5, h6 {
-    color: #000;
     line-height: 1.2em;
     margin-bottom: 0.6em;
 }
@@ -278,6 +277,19 @@ blockquote {
 }
 .clearfix {
     *zoom: 1;
+}
+.error {
+    margin: -80px 0 80px 0;
+    padding: 1em 0;
+    background-color: #F0DDDD;
+    color: #AA4444;
+}
+.error h2 {
+    font-size: 1.5em;
+    font-weight: bold;
+}
+.error p:last-child {
+    margin-bottom: 0;
 }
 
 /* Media Queries


### PR DESCRIPTION
Possible solution for #292 (alternative solution: #294), catches all `\Symfony\Component\Yaml\Exception\ParseException` and adds a `YAML_ParseError` meta variable with the error message.

It's up to theme designers to show this error message (therefore old themes don't show anything and the error is silently ignored). With the default theme the error message looks like:

![sub_page_pico_-_2015-11-29_20 59 10](https://cloud.githubusercontent.com/assets/920356/11459666/11fd8a70-96dc-11e5-9ba0-c620157377fc.png)
