### PR TITLE
Catch YAML parse errors (2)

### DIFF
--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -962,8 +962,7 @@ class Pico
                 try {
                     $meta = $this->parseFileMeta($rawContent, $headers);
                 } catch (\Symfony\Component\Yaml\Exception\ParseException $e) {
-                    $meta = array_fill_keys(array_keys($headers), '');
-                    $meta['time'] = $meta['date_formatted'] = '';
+                    $meta = $this->parseFileMeta('', $headers);
                     $meta['YAML_ParseError'] = $e->getMessage();
                 }
             } else {

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -971,9 +971,6 @@ class Pico
                 $meta = &$this->meta;
             }
 
-            // fallback to page id if page title is empty
-            $meta['title'] = (!empty($meta['title'])) ? $meta['title'] : $id;
-
             // build page data
             // title, description, author and date are assumed to be pretty basic data
             // everything else is accessible through $page['meta']


### PR DESCRIPTION
Possible solution for #292 (alternative solution: #293), catches all `\Symfony\Component\Yaml\Exception\ParseException` except for the current page and adds a `YAML_ParseError` meta variable with the error message. Therefore browsing to the erroneous page still shows the exception.