### PR TITLE
Website: Update custom Pico styling

### DIFF
--- a/_layouts/cover.html
+++ b/_layouts/cover.html
@@ -17,7 +17,7 @@
                 <div class="banner">
                     <ul>
                         <li data-transition="fade">
-                            <img src="style/images/art/slider-transparent.png" alt="" style="background-color:#707070" />
+                            <img src="style/images/art/slider-transparent.png" alt="" style="background-color:#2a2a2a" />
                             <div class="caption sfl huge" data-x="290" data-y="90" data-speed="300" data-start="100" data-easing="easeOutExpo">Introducing</div>
                             <div class="caption sft huge" data-x="600" data-y="90" data-speed="300" data-start="800" data-easing="easeOutExpo"><strong>Pico 1.0</strong></div>
                             <div class="caption sfl big" data-x="center" data-y="176" data-speed="300" data-start="1100" data-easing="easeOutExpo">A stupidly <em>simple</em> <span class="colored">&amp;</span> blazing <em>fast</em>, flat file CMS.</div>

--- a/_layouts/cover.html
+++ b/_layouts/cover.html
@@ -7,7 +7,7 @@
     <link href="{{ site.base_url }}" rel="canonical" />
 
 </head>
-<body class="full-layout">
+<body class="full-layout cover-layout">
 
     <div class="body-wrapper">
         <div class="top-wrapper">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,7 @@
     <link href="{{ site.base_url }}{{ page.url }}" rel="canonical" />
 
 </head>
-<body class="full-layout">
+<body class="full-layout default-layout">
 
     <div class="body-wrapper">
         <div class="top-wrapper">

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -6,7 +6,7 @@
     <link href="{{ site.base_url }}{{ page.url }}" rel="canonical" />
 
 </head>
-<body class="full-layout">
+<body class="full-layout docs-layout">
 
     <div class="body-wrapper">
         <div class="top-wrapper">

--- a/style.css
+++ b/style.css
@@ -501,28 +501,6 @@ p.description {
     -moz-transition: all 200ms ease-in;
     position: relative;
 }
-.menu ul li a:before {
-    content: "";
-    display: block;
-    position: absolute;
-    width: 4px;
-    height: 4px;
-    top: 11px;
-    left: -32px;
-    background: #3d3d3d;
-    /* Rotate */
-    -webkit-transform: rotate(-45deg);
-    -moz-transform: rotate(-45deg);
-    -ms-transform: rotate(-45deg);
-    -o-transform: rotate(-45deg);
-    transform: rotate(-45deg);
-    /* Rotate Origin */
-    -webkit-transform-origin: 0 100%;
-    -moz-transform-origin: 0 100%;
-    -ms-transform-origin: 0 100%;
-    -o-transform-origin: 0 100%;
-    transform-origin: 0 100%;
-}
 .menu ul li:first-child a:before,
 .menu ul ul li a:before {
     display: none
@@ -607,6 +585,9 @@ p.description {
     line-height: 20px;
     background-size: 30px 28px;
     -webkit-appearance: none;
+    -moz-appearance: none;
+    -ms-appearance: none;
+    appearance: none;
 }
 @media only screen and (-Webkit-min-device-pixel-ratio: 1.5), only screen and (-moz-min-device-pixel-ratio: 1.5), only screen and (-o-min-device-pixel-ratio: 3/2), only screen and (min-device-pixel-ratio: 1.5) {
 	.selectnav {
@@ -730,17 +711,11 @@ p.description {
 .box-wrapper .box:hover i.special {
     opacity: 1;
     color: #ff6760;
-    -webkit-animation: moveFromTop 300ms ease-in-out;
-    -moz-animation: moveFromTop 300ms ease-in-out;
-    -ms-animation: moveFromTop 300ms ease-in-out;
 }
 .box-wrapper .box:hover p,
 .box-wrapper .box:hover h3 {
     opacity: 1;
     color: #ff6760;
-    -webkit-animation: moveFromBottom 300ms ease-in-out;
-    -moz-animation: moveFromBottom 300ms ease-in-out;
-    -ms-animation: moveFromBottom 300ms ease-in-out;
 }
 @-webkit-keyframes moveFromBottom {
 	from {

--- a/style.css
+++ b/style.css
@@ -679,11 +679,11 @@ p.description {
     text-align: center;
     overflow: hidden;
     position: relative;
-    -webkit-transition: all 300ms linear;
-    -moz-transition: all 300ms linear;
-    -o-transition: all 300ms linear;
-    -ms-transition: all 300ms linear;
-    transition: all 300ms linear;
+    -webkit-transition: all 200ms linear;
+    -moz-transition: all 200ms linear;
+    -o-transition: all 200ms linear;
+    -ms-transition: all 200ms linear;
+    transition: all 200ms linear;
 }
 .box-wrapper .box p {
 	color: #616161 !important;
@@ -699,11 +699,11 @@ p.description {
 .box-wrapper .box h3,
 .box-wrapper .box p,
 .box-wrapper .box i.special {
-    -webkit-transition: all 300ms linear;
-    -moz-transition: all 300ms linear;
-    -o-transition: all 300ms linear;
-    -ms-transition: all 300ms linear;
-    transition: all 300ms linear;
+    -webkit-transition: all 200ms linear;
+    -moz-transition: all 200ms linear;
+    -o-transition: all 200ms linear;
+    -ms-transition: all 200ms linear;
+    transition: all 200ms linear;
 }
 .box-wrapper .box h3 {
     margin-bottom: 10px

--- a/style/css/color/pico.css
+++ b/style/css/color/pico.css
@@ -72,14 +72,20 @@ ul li:before {
 }
 .top-wrapper header {
     background: linear-gradient(135deg, #2eae9b 120px, #2a2a2a 40%);
+    border: 0 none;
+}
+.cover-layout .top-wrapper header {
     border-bottom: 1px solid transparent;
-    border-image: linear-gradient(135deg, #ffffff 120px, #2A2A2A 40%) 1;
+    border-image: linear-gradient(135deg, #B9B9B9 120px, #2A2A2A 40%) 1;
 }
 @media only screen and (max-width: 959px) {
     .top-wrapper header {
         background: linear-gradient(170deg, #2eae9b 0%, #2a2a2a 60%);
+        border: 0 none;
+    }
+    .cover-layout .top-wrapper header {
         border-bottom: 1px solid transparent;
-        border-image: linear-gradient(170deg, #ffffff 0%, #2A2A2A 60%) 1;
+        border-image: linear-gradient(170deg, #B9B9B9 0%, #2A2A2A 60%) 1;
     }
 }
 .menu ul li.active a,

--- a/style/css/color/pico.css
+++ b/style/css/color/pico.css
@@ -75,7 +75,7 @@ ul li:before {
 }
 @media only screen and (max-width: 959px) {
     .top-wrapper header {
-        background: linear-gradient(160deg, #2eae9b 0%, #2a2a2a 25%);
+        background: linear-gradient(170deg, #2eae9b 0%, #2a2a2a 60%);
     }
 }
 .menu ul li.active a,

--- a/style/css/color/pico.css
+++ b/style/css/color/pico.css
@@ -63,36 +63,25 @@ a.button,
 .page-navi ul li a {
     background-color: #2EAE9B;
 }
-a.button.red {
-    background-color: #2EAE9B;
+ul li:before {
+    color: #616161;
 }
 .lite1 {
     color: #2EAE9B;
     border-bottom: 1px dotted #2EAE9B;
 }
-.banner {
-    background: #707070;
+.top-wrapper header {
+    background: linear-gradient(135deg, #2eae9b 120px, #2a2a2a 40%);
 }
-.tp-loader {
-    background: url('../../images/spinner.gif') no-repeat !important;
-    background-color: #707070;
-}
-.top-wrapper header .inner {
-    padding: 56px 0 50px;
-}
-header {
-    background-color: #2EAE9B;
-}
-.menu ul li a {
-    color: #afe1da;
+@media only screen and (max-width: 959px) {
+    .top-wrapper header {
+        background: linear-gradient(160deg, #2eae9b 0%, #2a2a2a 25%);
+    }
 }
 .menu ul li.active a,
 .menu ul li a:hover,
 .menu ul li a.selected {
-    color: #fff
-}
-.menu ul li a:before{
-    background-color: #fff;
+    color: #2EAE9B
 }
 .menu ul li ul:before {
     border-bottom: 5px solid #2EAE9B;
@@ -110,29 +99,18 @@ header {
 .box-wrapper .box:hover h3 {
     color: #2EAE9B;
 }
-footer {
-    background-color: #c0c0c0;
+footer a {
+    color: #2EAE9B;
 }
-footer h1, footer h2, footer h3, footer h4, footer h5, footer h6 {
-    color: #616161;
-}
-footer p.description {
-    color: #262626;
-}
-footer p.description a {
+footer a:hover {
     color: #fff;
-}
-footer p.description a:hover {
-    color: #2EAE9B !important;
-}
-.subfooter-wrapper {
-    background-color: #707070;
 }
 .subfooter-wrapper a {
-    color: #fff;
+    color: #2EAE9B;
+    border-bottom: 0 none;
 }
 .subfooter-wrapper a:hover {
-    color: #2EAE9B
+    color: #fff;
 }
 ul.contact-info li i {
     color: #2EAE9B;
@@ -181,7 +159,7 @@ ul.contact-info li i {
     background-color: #2EAE9B;
 }
 .touchcarousel .touchcarousel-item .caption a:hover {
-	color: #2EAE9B;
+    color: #2EAE9B;
 }
 .touch-carousel .scrollbar {
     background-color: #2EAE9B !important;

--- a/style/css/color/pico.css
+++ b/style/css/color/pico.css
@@ -72,10 +72,14 @@ ul li:before {
 }
 .top-wrapper header {
     background: linear-gradient(135deg, #2eae9b 120px, #2a2a2a 40%);
+    border-bottom: 1px solid transparent;
+    border-image: linear-gradient(135deg, #ffffff 120px, #2A2A2A 40%) 1;
 }
 @media only screen and (max-width: 959px) {
     .top-wrapper header {
         background: linear-gradient(170deg, #2eae9b 0%, #2a2a2a 60%);
+        border-bottom: 1px solid transparent;
+        border-image: linear-gradient(170deg, #ffffff 0%, #2A2A2A 60%) 1;
     }
 }
 .menu ul li.active a,


### PR DESCRIPTION
The [Webpaint theme](http://themes.iki-bir.com/webpaint/multipage/full/) is a dark theme - transforming it into an light theme (8deb744fed2120892678e8e333787e2ae7670200) makes it, to say it in @smcdougall's words, "loose a few points of elegance"... I turned it back into a dark theme, but added a gradient to the header to present Pico's "corporate color" a little more prominent.

**Live demo:** http://phrozenbyte.github.io/Pico/
(Note: clicking on links doesn't work, you must change URLs manually)

![pico_-_a_stupidly_simple _blazing_fast _flat_file_cms _-_2015-12-16_23 12 17](https://cloud.githubusercontent.com/assets/920356/11855443/978bb20e-a44a-11e5-9e88-6516be582400.png)
