### PR TITLE
Nitrous.io Quickstart button

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ $ curl -sS https://getcomposer.org/installer | php
 $ php composer.phar install
 ```
 
+Nitrous Quickstart
+------------------
+
+You can quickly create a free development environment for this Pico project in the cloud on www.nitrous.io:
+
+<a href="https://www.nitrous.io/quickstart">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous Quickstart" width=142 height=34>
+</a>
+
+Simply access your site via the `Preview > 3000` link in the IDE.
+
 Upgrade
 -------
 

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -1,0 +1,9 @@
+# Setup
+
+Welcome to your Pico project on Nitrous.
+
+Now you've got a development server running and can see the output in the Nitrous terminal window. You can open up a new shell or utilize [tmux](https://community.nitrous.io/docs/tmux) to open new shells to run other commands.
+
+## Preview the app
+
+In the Nitrous IDE, open the "Preview" menu and click "Port 3000".

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,9 @@
+{
+  "template": "php-apache",
+  "ports": [3000],
+  "name": "Pico",
+  "description": "Pico is a stupidly simple, blazing fast, flat file CMS.",
+  "scripts": {
+    "post-create": "rm -rf ~/code/public_html && cd ~/code/Pico && composer install && cd ~/code && mv Pico public_html && sudo chown -R nitrous:www-data public_html"
+  }
+}


### PR DESCRIPTION
Added Nitrous Quickstart files so anyone can quickly spin up a free, cloud dev environment to start using this repo. Clicking the Quickstart button will automatically clone this repo and will install and configure any required packages.