### PR TITLE
Enhancement: added %include% tag

### DIFF
--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -875,7 +875,7 @@ class Pico
             . "(?:(.*?)(?:\r)?\n)?(?(2)\*\/|---)[[:blank:]]*(?:(?:\r)?\n|$)/s";
         $content = preg_replace($metaHeaderPattern, '', $rawContent, 1);
 
-		// process included files
+        // process included files
 		if (preg_match('|%include%\s*(["\'])(.*?)\1|smi', $content, $matches) > 0) {
             $includeFile = $this->getConfig('content_dir') . $matches[2];
             if (!file_exists($includeFile))

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -876,14 +876,16 @@ class Pico
         $content = preg_replace($metaHeaderPattern, '', $rawContent, 1);
 
         // process included files
-        if (preg_match('|%include%\s*(["\'])(.*?)\1|smi', $content, $matches) > 0) {
-            $includeFile = $this->getConfig('content_dir') . $matches[2];
+        $includeTokensCount = preg_match_all('|%include%\s*(["\'])(.*?)\1|smi', $content, $matches);
+        for ($i = 0; $i < $includeTokensCount; $i++) {
+            $includeFile = $this->getConfig('content_dir') . $matches[2][$i];
             if (!file_exists($includeFile)) {
-                throw new RuntimeException('Required "' . $includeFile . '" not found');
+                throw new RuntimeException('Unable to include file "' . $includeFile .
+                    '" referenced from "' . $this->requestFile . '"');
             }
             $includeContent = $this->loadFileContent($includeFile);
             $includeContent = preg_replace($metaHeaderPattern, '', $includeContent, 1);
-            $content = str_replace($matches[0], $includeContent, $content);
+            $content = str_replace($matches[0][$i], $includeContent, $content);
         }
 
         // replace %site_title%

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -877,14 +877,14 @@ class Pico
 
 		// process included files
 		if (preg_match('|%include%\s*(["\'])(.*?)\1|smi', $content, $matches) > 0) {
-			$includeFile = $this->getConfig('content_dir') . $matches[2];			
-			if (!file_exists($includeFile))
-				throw new RuntimeException('Required "' . $includeFile . '" not found');	
-			$includeContent = $this->loadFileContent($includeFile);
-			$includeContent = preg_replace($metaHeaderPattern, '', $includeContent, 1);
-			$content = str_replace($matches[0], $includeContent, $content);
-		}		
-		
+            $includeFile = $this->getConfig('content_dir') . $matches[2];
+            if (!file_exists($includeFile))
+                throw new RuntimeException('Required "' . $includeFile . '" not found');
+            $includeContent = $this->loadFileContent($includeFile);
+            $includeContent = preg_replace($metaHeaderPattern, '', $includeContent, 1);
+            $content = str_replace($matches[0], $includeContent, $content);
+        }
+
         // replace %site_title%
         $content = str_replace('%site_title%', $this->getConfig('site_title'), $content);
 

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -876,7 +876,7 @@ class Pico
         $content = preg_replace($metaHeaderPattern, '', $rawContent, 1);
 
         // process included files
-		if (preg_match('|%include%\s*(["\'])(.*?)\1|smi', $content, $matches) > 0) {
+        if (preg_match('|%include%\s*(["\'])(.*?)\1|smi', $content, $matches) > 0) {
             $includeFile = $this->getConfig('content_dir') . $matches[2];
             if (!file_exists($includeFile)) {
                 throw new RuntimeException('Required "' . $includeFile . '" not found');

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -878,8 +878,9 @@ class Pico
         // process included files
 		if (preg_match('|%include%\s*(["\'])(.*?)\1|smi', $content, $matches) > 0) {
             $includeFile = $this->getConfig('content_dir') . $matches[2];
-            if (!file_exists($includeFile))
+            if (!file_exists($includeFile)) {
                 throw new RuntimeException('Required "' . $includeFile . '" not found');
+            }
             $includeContent = $this->loadFileContent($includeFile);
             $includeContent = preg_replace($metaHeaderPattern, '', $includeContent, 1);
             $content = str_replace($matches[0], $includeContent, $content);

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -875,6 +875,16 @@ class Pico
             . "(?:(.*?)(?:\r)?\n)?(?(2)\*\/|---)[[:blank:]]*(?:(?:\r)?\n|$)/s";
         $content = preg_replace($metaHeaderPattern, '', $rawContent, 1);
 
+		// process included files
+		if (preg_match('|%include%\s*(["\'])(.*?)\1|smi', $content, $matches) > 0) {
+			$includeFile = $this->getConfig('content_dir') . $matches[2];			
+			if (!file_exists($includeFile))
+				throw new RuntimeException('Required "' . $includeFile . '" not found');	
+			$includeContent = $this->loadFileContent($includeFile);
+			$includeContent = preg_replace($metaHeaderPattern, '', $includeContent, 1);
+			$content = str_replace($matches[0], $includeContent, $content);
+		}		
+		
         // replace %site_title%
         $content = str_replace('%site_title%', $this->getConfig('site_title'), $content);
 


### PR DESCRIPTION
Introduced `%include%` tag that allows to include file content from an external file.

Usage in content files:

```md
%include% "/path/to/file/to/include.md"
```

Included file can have meta-variables to be replaced with values defined in parent file.
For example:

**parent.md**:
```md
---
username: John Doe 
---
Hello, %include% "child.md"
```

**child.md**:
```md
%meta.username%. This is an example how include tag works.
```

Will be processed to:
```md
Hello, John Doe. This is an example how include tag works.
```
