### PR TITLE
stop config.yml on loading again

### DIFF
--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -894,7 +894,7 @@ class Pico
         // merge $config of config/*.yml files
         $configFiles = $this->getFilesGlob($this->getConfigDir() . '*.yml');
         foreach ($configFiles as $configFile) {
-            if ($configFile !== 'config.yml') {
+            if ($configFile !== $this->getConfigDir() . 'config.yml') {
                 $this->config += $loadConfigClosure($configFile);
             }
         }


### PR DESCRIPTION
When loading all other .yml files in the config dir, the config file is loaded again because the if condition is not correct. `$configFile` include the path to the file. 