### PR TITLE
add support for windows path on evaluateRequestUrl() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,10 @@ Pico Changelog
           are only possible with a new major version.
 
 ### Version 2.0.2
-Released: 2018-08-06
+Released: -
 
 ```
-* [Changed] Support Windows path ("\" instead of "/") on evaluateRequestUrl() method
+* [Fixed] Support Windows paths (`\` instead of `/`) in `Pico::evaluateRequestUrl()`
 ```
 
 ### Version 2.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Pico Changelog
           `PicoDeprecated`'s changelog. Please note that BC-breaking changes
           are only possible with a new major version.
 
+### Version 2.0.2
+Released: 2018-08-06
+
+```
+* [Changed] Support Windows path ("\" instead of "/") on evaluateRequestUrl() method
+```
+
 ### Version 2.0.1
 Released: 2018-07-29
 

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -1076,7 +1076,7 @@ class Pico
         // use REQUEST_URI (requires URL rewriting); e.g. /pico/sub/page
         if (($this->requestUrl === null) && $this->isUrlRewritingEnabled()) {
             $basePath = dirname($_SERVER['SCRIPT_NAME']);
-            $basePath = !in_array($basePath, array('.', '/'), true) ? $basePath . '/' : '/';
+            $basePath = !in_array($basePath, array('.', '/', '\\'), true) ? $basePath . '/' : '/';
             $basePathLength = strlen($basePath);
 
             $requestUri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';


### PR DESCRIPTION
On evaluateRequestUrl() method we need to consider the windows way to describe a path. In fact it uses slash instead of back-slash.
With this fix we can use PicoCMS on both platform.