### PR TITLE
"patch-1": Make index.php.dist runnable from top directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Do you know the feeling: You want to install a new website, so you upload all fi
 
 ###### Step 1
 
-[Download the latest Pico release][LatestRelease] and upload all files to the `httpdocs` directory (e.g. `/var/www/html`) of your server.
+[Download the latest Pico release][LatestRelease] and upload all files to the `httpdocs` directory (e.g. `/var/www/html`) of your server. Alternatively you can create a new directory called `picocms` in `httpdocs` directory (e.g. resulting path `/var/www/html/picocms`) and upload all files there. Then copy index.php to the httpdocs directory (e.g. there: `/var/www/html/index.php`)
+
 
 ###### Step 2
 

--- a/index.php.dist
+++ b/index.php.dist
@@ -10,6 +10,12 @@
  * License-Filename: LICENSE
  */
 
+/**
+ * You can leave this file in picocms main install dir, then you don't have to do anything.
+ * Or you can put it in the top directory (so that it stands besides the picocms install dir which must be called "picocms" then).
+ */
+
+
 // check PHP platform requirements
 if (PHP_VERSION_ID < 50306) {
     die('Pico requires PHP 5.3.6 or above to run');
@@ -21,12 +27,18 @@ if (!extension_loaded('mbstring')) {
     die("Pico requires the PHP extension 'mbstring' to run");
 }
 
+
+$newroot = '';
+if (file_exists('picocms')) {
+	$newroot = '/picocms';
+}
+
 // load dependencies
-require_once(__DIR__ . '/vendor/autoload.php');
+require_once(__DIR__ . $newroot . '/vendor/autoload.php');
 
 // instance Pico
 $pico = new Pico(
-    __DIR__,    // root dir
+    __DIR__ . $newroot,    // root dir
     'config/',  // config dir
     'plugins/', // plugins dir
     'themes/'   // themes dir


### PR DESCRIPTION
Objective is that you don't have to unpack the picocms package in the http(s) servers root path as single files but put it in a directory called "picocms" while keeping it accessible by "http://top.level.domain/?sub".

<!--

Developer Certificate of Origin
===============================

By contributing to Pico, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to Pico. Please refer to the *Developer Certificate of Origin* section in Pico's [`CONTRIBUTING.md`](https://github.com/picocms/Pico/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

-->
