### PR TITLE
[Fixed] Get current port from current host in 'Pico::getBaseUrl()'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Pico Changelog
 Released: -
 
 ```
+* [Fixed] Get current port from current host in 'Pico::getBaseUrl()'
 * [Changed] Improve documentation
 ```
 

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -2054,8 +2054,8 @@ class Pico
 
         $hostPortPosition = ($host[0] === '[') ? strpos($host, ':', strrpos($host, ']') ?: 0) : strrpos($host, ':');
         if ($hostPortPosition !== false) {
-			$port = (int) substr($host, $hostPortPosition + 1);
-			$host = substr($host, 0, $hostPortPosition);
+		$port = (int) substr($host, $hostPortPosition + 1);
+		$host = substr($host, 0, $hostPortPosition);
         }
 
         $protocol = 'http';

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -2054,8 +2054,8 @@ class Pico
 
         $hostPortPosition = ($host[0] === '[') ? strpos($host, ':', strrpos($host, ']') ?: 0) : strrpos($host, ':');
         if ($hostPortPosition !== false) {
-            $host = substr($host, 0, $hostPortPosition);
             $port = (int) substr($host, $hostPortPosition + 1);
+			$host = substr($host, 0, $hostPortPosition);
         }
 
         $protocol = 'http';

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -2054,7 +2054,7 @@ class Pico
 
         $hostPortPosition = ($host[0] === '[') ? strpos($host, ':', strrpos($host, ']') ?: 0) : strrpos($host, ':');
         if ($hostPortPosition !== false) {
-            $port = (int) substr($host, $hostPortPosition + 1);
+			$port = (int) substr($host, $hostPortPosition + 1);
 			$host = substr($host, 0, $hostPortPosition);
         }
 

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -2054,8 +2054,8 @@ class Pico
 
         $hostPortPosition = ($host[0] === '[') ? strpos($host, ':', strrpos($host, ']') ?: 0) : strrpos($host, ':');
         if ($hostPortPosition !== false) {
-		$port = (int) substr($host, $hostPortPosition + 1);
-		$host = substr($host, 0, $hostPortPosition);
+    		$port = (int) substr($host, $hostPortPosition + 1);
+    		$host = substr($host, 0, $hostPortPosition);
         }
 
         $protocol = 'http';


### PR DESCRIPTION
Getting current port from current host before changing $host variabile at line 2057