### PR TITLE
Enhancement: require mbstring polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/yaml" : "^2.8",
         "erusev/parsedown": "^1.8|1.8.0@beta",
         "erusev/parsedown-extra": "^0.8|0.8.0@beta",
-        "symphony/polyfill-mbstring": "^1.12"
+        "symfony/polyfill-mbstring": "^1.12"
     },
     "suggest": {
         "picocms/pico-theme": "Pico requires a theme to actually display the contents of your website. This is Pico's official default theme.",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "twig/twig": "^1.35",
         "symfony/yaml" : "^2.8",
         "erusev/parsedown": "^1.8|1.8.0@beta",
-        "erusev/parsedown-extra": "^0.8|0.8.0@beta"
+        "erusev/parsedown-extra": "^0.8|0.8.0@beta",
+        "symphony/polyfill-mbstring": "^1.12"
     },
     "suggest": {
         "picocms/pico-theme": "Pico requires a theme to actually display the contents of your website. This is Pico's official default theme.",


### PR DESCRIPTION
c/f [#509/551912485](https://github.com/picocms/Pico/issues/509#issuecomment-551912485)

On some webhosts, `php-mbstring` may not be available; including [this 27KiB library](https://github.com/symfony/polyfill-mbstring) remedies those cases.