### PR TITLE
Add option to set a locale

### DIFF
--- a/config/config.yml.template
+++ b/config/config.yml.template
@@ -7,6 +7,7 @@ base_url: ~                         # Pico will try to guess its base URL, if th
 rewrite_url: ~                      # A boolean (true or false) indicating whether URL rewriting is forced
 debug: ~                            # Set this to true to enable Pico's debug mode
 timezone: ~                         # Your PHP installation might require you to manually specify a timezone
+locale: ~                           # Your PHP installation might require you to manually specify a locale to use
 
 ##
 # Theme

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -936,6 +936,7 @@ class Pico
             'rewrite_url' => null,
             'debug' => null,
             'timezone' => null,
+            'locale' => null,
             'theme' => 'default',
             'theme_config' => null,
             'theme_meta' => null,
@@ -973,6 +974,10 @@ class Pico
             $this->config['timezone'] = @date_default_timezone_get();
         }
         date_default_timezone_set($this->config['timezone']);
+
+        if ($this->config['locale'] !== null) {
+            setlocale(LC_ALL, $this->config['locale']);
+        }
 
         if (!$this->config['plugins_url']) {
             $this->config['plugins_url'] = $this->getUrlFromPath($this->getPluginsDir());


### PR DESCRIPTION
As mentioned in https://www.php.net/manual/en/function.basename.php both
basename() and dirname() are locale aware.
An incorrect locale can cause the page tree to behave in strange ways.

For example the structure

/über-uns
 |-index.md
 |-impressum.md

could lead to the page impressum not being a child of über-uns.

<!--

Developer Certificate of Origin
===============================

By contributing to Pico, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to Pico. Please refer to the *Developer Certificate of Origin* section in Pico's [`CONTRIBUTING.md`](https://github.com/picocms/Pico/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

-->
