### PR TITLE
Enhancement : php8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "source": "https://github.com/picocms/Pico"
     },
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=7.2.5||^8.0",
         "ext-mbstring": "*",
         "twig/twig": "^3.3.8",
         "symfony/yaml" : "^5.4.3",
@@ -55,6 +55,16 @@
         "branch-alias": {
             "dev-master": "2.1.x-dev",
             "dev-pico-3.0": "3.0.x-dev"
+        }
+    },
+    "config": {
+        "platform": {
+            "php": "7.2.5"
+        },
+        "platform-check": true,
+        "sort-packages": true,
+        "allow-plugins": {
+            "picocms/composer-installer": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
         "ext-mbstring": "*",
         "twig/twig": "^3.3.8",
         "symfony/yaml" : "^5.4.3",
-        "erusev/parsedown": "1.7.4",
-        "erusev/parsedown-extra": "0.8.1"
+        "erusev/parsedown": "^2.0.0-beta-1",
+        "erusev/parsedown-extra": "^2.0.0-beta-1"
     },
     "suggest": {
         "picocms/pico-theme": "Pico requires a theme to actually display the contents of your website. This is Pico's official default theme.",

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -675,7 +675,7 @@ class Pico
     {
         // scope isolated require()
         $includeClosure = static function ($pluginFile) {
-            require($pluginFile);
+            require_once($pluginFile);
         };
 
         $pluginBlacklist = array_fill_keys($pluginBlacklist, true);

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -61,6 +61,12 @@ use Twig\TwigFilter;
  * @license https://opensource.org/licenses/MIT The MIT License
  * @version 3.0
  */
+
+use Erusev\Parsedown\Configurables\Breaks;
+use Erusev\Parsedown\Parsedown;
+use Erusev\Parsedown\State;
+use Erusev\ParsedownExtra\ParsedownExtra;
+
 class Pico
 {
     /**
@@ -1587,15 +1593,13 @@ class Pico
     public function getParsedown(): Parsedown
     {
         if ($this->parsedown === null) {
-            if ($this->config['content_config']['extra']) {
-                $this->parsedown = new ParsedownExtra();
-            } else {
-                $this->parsedown = new Parsedown();
+            $state = new State([
+                new Breaks((bool) $this->config['content_config']['breaks'])
+            ]);
+            if ($this->config['content_config']['extra']){
+                $state = new ParsedownExtra($state);
             }
-
-            $this->parsedown->setBreaksEnabled((bool) $this->config['content_config']['breaks']);
-            $this->parsedown->setMarkupEscaped((bool) $this->config['content_config']['escape']);
-            $this->parsedown->setUrlsLinked((bool) $this->config['content_config']['auto_urls']);
+            $this->parsedown = new Parsedown($state);
 
             $this->triggerEvent('onParsedownRegistered', [ &$this->parsedown ]);
         }
@@ -1711,14 +1715,14 @@ class Pico
      * @see Pico::getFileContent()
      *
      * @param string $markdown   Markdown contents of a page
-     * @param bool   $singleLine whether to parse just a single line of markup
+     * @param bool   $singleLine whether to parse just a single line of markup (deprecated because not needed and not used)
      *
      * @return string parsed contents (HTML)
      */
     public function parseFileContent(string $markdown, bool $singleLine = false): string
     {
         $markdownParser = $this->getParsedown();
-        return !$singleLine ? @$markdownParser->text($markdown) : @$markdownParser->line($markdown);
+        return @$markdownParser->toHtml($markdown);
     }
 
     /**

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -2147,12 +2147,12 @@ class Pico
         if ($this->twig === null) {
             $twigConfig = $this->getConfig('twig_config');
 
-            $twigLoader = new TwigFilesystemLoader($this->getThemesDir() . $this->getTheme());
-            $this->twig = new TwigEnvironment($twigLoader, $twigConfig);
+            $twigLoader = new \Twig\Loader\FilesystemLoader($this->getThemesDir() . $this->getTheme());
+            $this->twig = new \Twig\Environment($twigLoader, $twigConfig);
             $this->twig->addExtension(new PicoTwigExtension($this));
 
             if (!empty($twigConfig['debug'])) {
-                $this->twig->addExtension(new TwigDebugExtension());
+                $this->twig->addExtension(new Twig\Extension\DebugExtension());
             }
 
             // register content filter
@@ -2160,7 +2160,7 @@ class Pico
             // this is the reason why we can't register this filter as part of PicoTwigExtension
             $pico = $this;
             $pages = &$this->pages;
-            $this->twig->addFilter(new TwigFilter(
+            $this->twig->addFilter(new \Twig\TwigFilter(
                 'content',
                 function ($page) use ($pico, &$pages) {
                     if (isset($pages[$page])) {
@@ -2201,7 +2201,7 @@ class Pico
             'theme_url' => $this->getConfig('themes_url') . $this->getTheme(),
             'site_title' => $this->getConfig('site_title'),
             'meta' => $this->meta,
-            'content' => new TwigMarkup($this->content, 'UTF-8'),
+            'content' => new \Twig\Markup($this->content, 'UTF-8'),
             'pages' => $this->pages,
             'previous_page' => $this->previousPage,
             'current_page' => $this->currentPage,

--- a/lib/PicoTwigExtension.php
+++ b/lib/PicoTwigExtension.php
@@ -75,16 +75,21 @@ class PicoTwigExtension extends AbstractTwigExtension
      *
      * @see TwigExtensionInterface::getFilters()
      *
-     * @return TwigFilter[] array of Pico's Twig filters
+     * @return \Twig\TwigFilter[] array of Pico's Twig filters
      */
     public function getFilters(): array
     {
-        return [
-            'markdown' => new TwigFilter('markdown', [ $this, 'markdownFilter' ], [ 'is_safe' => [ 'html' ] ]),
-            'sort_by' => new TwigFilter('sort_by', [ $this, 'sortByFilter' ]),
-            'link' => new TwigFilter('link', [ $this->pico, 'getPageUrl' ]),
-            'url' => new TwigFilter('url', [ $this->pico, 'substituteUrl' ]),
-        ];
+        return array(
+            'markdown' => new \Twig\TwigFilter(
+                'markdown',
+                array($this, 'markdownFilter'),
+                array('is_safe' => array('html'))
+            ),
+            'map' => new \Twig\TwigFilter('map', array($this, 'mapFilter')),
+            'sort_by' => new \Twig\TwigFilter('sort_by', array($this, 'sortByFilter')),
+            'link' => new \Twig\TwigFilter('link', array($this->pico, 'getPageUrl')),
+            'url' => new \Twig\TwigFilter('url', array($this->pico, 'substituteUrl'))
+        );
     }
 
     /**


### PR DESCRIPTION
## _Or how to make pico working without warnings with php8._

> I am developer in a small French team in Brittany to make a small CMS based on Pico. We find picocms as a real simple and small impact solution. The team is a group of volunteers into the association Defis.
>
> To work on php 8, we have tests some improvements, we want to share them to the core with this PR.
>
> _I hope I have used contributing standards by writing this PR. Keep me in mind if there is improvement for next time._ Thanks :wink: 

**What do this PR**:
 - in 2 commits
 - define `composer.json` to be able to use `php 8`
 - update references to `Twig` because the previous way creates warnings
 - update `parsedown` to `beta` revision to be able to remove warnings due to `php 8.0`
 - update `composer.lock`
 
**BREAKING_CHANGES**:
 - there is small BREAKING_CHANGES with options see https://github.com/picocms/Pico/commit/eb9caf22fe0c16356a7b16898bdeeeb83049f16a

**how to test**:
 - go to commit
 - do `composer install`
 - test

**idea of improvement**:
 - if possible, give me idea not to create breaking changes if there are really needed
 - if you have a community channel to speak directly, it is possible. I have found https://web.libera.chat/#picocms. Let me know what you prefer.

**Thank you, the whole team of dev. tester, users, for this sober cms, well written and secure. :+1:**

_our custom repository for our project is not stable, we prefer currently share the link via not public channels not to share not stable links if you want to see it_