### PR TITLE
Add Event Triggers to `content` Filter

### DIFF
--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -2169,7 +2169,9 @@ class Pico
                         $pageData = &$pages[$page];
                         if (!isset($pageData['content'])) {
                             $markdown = $pico->prepareFileContent($pageData['raw_content'], $pageData['meta'], $page);
+                            $this->triggerEvent('onContentPrepared', [ &$markdown ]);
                             $pageData['content'] = $pico->parseFileContent($markdown);
+                            $this->triggerEvent('onContentParsed', [ &$pageData['content'] ]);
                         }
                         return $pageData['content'];
                     }

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -1877,11 +1877,22 @@ class Pico
         if ($orderBy === 'meta') {
             // sort by arbitrary meta value
             $orderByMeta = $this->getConfig('pages_order_by_meta');
-            uasort($this->pages, function ($a, $b) use ($alphaSortClosure, $order, $orderByMeta) {
-                $aSortValue = isset($a['meta'][$orderByMeta]) ? $a['meta'][$orderByMeta] : null;
+            // Split the configuration value into an array of keys to allow sorting by nested meta values.
+            $orderByMetaKeys = explode('.', $orderByMeta);
+
+            uasort($this->pages, function ($a, $b) use ($alphaSortClosure, $order, $orderByMetaKeys) {
+                $aMeta = $a['meta'];
+                $bMeta = $b['meta'];
+                // Iterate through the meta keys to drill down into nested arrays for the final sort value.
+                foreach ($orderByMetaKeys as $key) {
+                    $aMeta = isset($aMeta[$key]) ? $aMeta[$key] : null;
+                    $bMeta = isset($bMeta[$key]) ? $bMeta[$key] : null;
+                }
+
+                $aSortValue = $aMeta;
                 $aSortValueNull = ($aSortValue === null);
 
-                $bSortValue = isset($b['meta'][$orderByMeta]) ? $b['meta'][$orderByMeta] : null;
+                $bSortValue = $bMeta;
                 $bSortValueNull = ($bSortValue === null);
 
                 $cmp = 0;


### PR DESCRIPTION
In this merge I add important event triggers to improve the consistency in the functionality of PicoCMS. Previously, the `onContentPrepared` and `onContentParsed` events were only triggered when a page was called directly. 

This limitation led to problems with plugins that rely on these events, especially if the content was processed via the internal Twig filter `content`. The added event triggers in the `content` filter ensure that all plugins involved in content creation work smoothly even when the `content` filter is used. 

This change ensures broader and more reliable plugin compatibility within PicoCMS.