### PR TITLE
Enhanced Sorting by Nested Meta Values in Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Released: -
         now receive the (optional) `$pageId` argument for the new `%page_*%`
         Markdown placeholders
 * [New] Add `page()` Twig function to access a page's data
+* [New] Enhance `pages_order_by_meta` functionality to allow sorting by nested meta values using '.' notation (e.g., 'author.info')
 * [Changed] ! Pico now requires PHP 7.2.5 or later (this includes full PHP 8
             support, also see #528, #534, #608)
 * [Changed] ! Pico now depends on Twig 3.3, skipping Twig 2.x altogether; this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ Released: -
         now receive the (optional) `$pageId` argument for the new `%page_*%`
         Markdown placeholders
 * [New] Add `page()` Twig function to access a page's data
-* [New] Enhance `pages_order_by_meta` functionality to allow sorting by nested meta values using '.' notation (e.g., 'author.info')
+* [New] Enhance `pages_order_by_meta` functionality to allow sorting by 
+            nested meta values using '.' notation (e.g., 'author.info')
 * [Changed] ! Pico now requires PHP 7.2.5 or later (this includes full PHP 8
             support, also see #528, #534, #608)
 * [Changed] ! Pico now depends on Twig 3.3, skipping Twig 2.x altogether; this

--- a/config/config.yml.template
+++ b/config/config.yml.template
@@ -30,8 +30,8 @@ twig_config:                        # Twig template engine config
 #
 date_format: "%D %T"                # Pico's default date format;
                                     #     See https://php.net/manual/en/function.strftime.php for more info
-pages_order_by_meta: author         # Sort pages by meta value "author" (set "pages_order_by" to "meta"); use '.' for nested meta keys (e.g., 'author.info')
-pages_order_by: alpha               # Change how Pico sorts pages ("alpha" for alphabetical order, "date", or "meta")
+pages_order_by_meta: author         # Sort pages by meta value "author" (set "pages_order_by" to "meta")
+                                    #     Use '.' notation for nested meta keys (e.g. 'author.info')
 pages_order: asc                    # Sort pages in ascending ("asc") or descending ("desc") order
 content_dir: ~                      # The path to Pico's content directory
 content_ext: .md                    # The file extension of your Markdown files

--- a/config/config.yml.template
+++ b/config/config.yml.template
@@ -30,7 +30,7 @@ twig_config:                        # Twig template engine config
 #
 date_format: "%D %T"                # Pico's default date format;
                                     #     See https://php.net/manual/en/function.strftime.php for more info
-pages_order_by_meta: author         # Sort pages by meta value "author" (set "pages_order_by" to "meta")
+pages_order_by_meta: author         # Sort pages by meta value "author" (set "pages_order_by" to "meta"); use '.' for nested meta keys (e.g., 'author.info')
 pages_order_by: alpha               # Change how Pico sorts pages ("alpha" for alphabetical order, "date", or "meta")
 pages_order: asc                    # Sort pages in ascending ("asc") or descending ("desc") order
 content_dir: ~                      # The path to Pico's content directory

--- a/config/config.yml.template
+++ b/config/config.yml.template
@@ -32,6 +32,7 @@ date_format: "%D %T"                # Pico's default date format;
                                     #     See https://php.net/manual/en/function.strftime.php for more info
 pages_order_by_meta: author         # Sort pages by meta value "author" (set "pages_order_by" to "meta")
                                     #     Use '.' notation for nested meta keys (e.g. 'author.info')
+pages_order_by: alpha               # Change how Pico sorts pages ("alpha" for alphabetical order, "date", or "meta")
 pages_order: asc                    # Sort pages in ascending ("asc") or descending ("desc") order
 content_dir: ~                      # The path to Pico's content directory
 content_ext: .md                    # The file extension of your Markdown files

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -1877,22 +1877,18 @@ class Pico
         if ($orderBy === 'meta') {
             // sort by arbitrary meta value
             $orderByMeta = $this->getConfig('pages_order_by_meta');
-            // Split the configuration value into an array of keys to allow sorting by nested meta values.
             $orderByMetaKeys = explode('.', $orderByMeta);
 
             uasort($this->pages, function ($a, $b) use ($alphaSortClosure, $order, $orderByMetaKeys) {
-                $aMeta = $a['meta'];
-                $bMeta = $b['meta'];
-                // Iterate through the meta keys to drill down into nested arrays for the final sort value.
+                $aSortValue = $a['meta'];
+                $bSortValue = $b['meta'];
+                
                 foreach ($orderByMetaKeys as $key) {
-                    $aMeta = isset($aMeta[$key]) ? $aMeta[$key] : null;
-                    $bMeta = isset($bMeta[$key]) ? $bMeta[$key] : null;
+                    $aSortValue = isset($aSortValue[$key]) ? $aSortValue[$key] : null;
+                    $bSortValue = isset($bSortValue[$key]) ? $bSortValue[$key] : null;
                 }
 
-                $aSortValue = $aMeta;
                 $aSortValueNull = ($aSortValue === null);
-
-                $bSortValue = $bMeta;
                 $bSortValueNull = ($bSortValue === null);
 
                 $cmp = 0;

--- a/lib/Pico.php
+++ b/lib/Pico.php
@@ -1877,11 +1877,22 @@ class Pico
         if ($orderBy === 'meta') {
             // sort by arbitrary meta value
             $orderByMeta = $this->getConfig('pages_order_by_meta');
-            uasort($this->pages, function ($a, $b) use ($alphaSortClosure, $order, $orderByMeta) {
-                $aSortValue = isset($a['meta'][$orderByMeta]) ? $a['meta'][$orderByMeta] : null;
+            // Split the configuration value into an array of keys to allow sorting by nested meta values.
+            $orderByMetaKeys = explode('.', $orderByMeta);
+
+            uasort($this->pages, function ($a, $b) use ($alphaSortClosure, $order, $orderByMetaKeys) {
+                $aMeta = $a['meta'];
+                $bMeta = $b['meta'];
+                // Iterate through the meta keys to drill down into nested arrays for the final sort value.
+                foreach ($orderByMetaKeys as $key) {
+                    $aMeta = isset($aMeta[$key]) ? $aMeta[$key] : null;
+                    $bMeta = isset($bMeta[$key]) ? $bMeta[$key] : null;
+                }
+
+                $aSortValue = $aMeta;
                 $aSortValueNull = ($aSortValue === null);
 
-                $bSortValue = isset($b['meta'][$orderByMeta]) ? $b['meta'][$orderByMeta] : null;
+                $bSortValue = $bMeta;
                 $bSortValueNull = ($bSortValue === null);
 
                 $cmp = 0;


### PR DESCRIPTION
This pull request introduces an enhancement to the sorting functionality within pages. Previously, sorting was limited to top-level meta values. With this update, the sorting logic now supports nested meta values, providing greater flexibility and precision in organizing content.

Key Changes:

- Extended the pages_order_by_meta configuration to interpret dot-separated strings as paths to nested meta values.
- Updated the sorting algorithm to recursively access nested meta values based on the provided path.
- 
This enhancement ensures a more dynamic and versatile approach to content organization, particularly beneficial for complex page structures with deeply nested meta data.